### PR TITLE
Add i.imgur.com as a valid domain for the imgur handler

### DIFF
--- a/src/reddit/compile.ts
+++ b/src/reddit/compile.ts
@@ -41,6 +41,7 @@ function getDomainHandler(domain?: string) {
                 type: 'summary',
             };
         case 'imgur.com':
+        case 'i.imgur.com':
             return {
                 handler: externalImageEmbed,
                 type: 'article',


### PR DESCRIPTION
I noticed some issues embedding imgur posts. I discovered that sometimes the post domain is set to `i.imgur.com`, which leads it to not embed correctly. 