### PR TITLE
Allow twitch embedding from non clips subdomain

### DIFF
--- a/src/embeds/twitch.ts
+++ b/src/embeds/twitch.ts
@@ -25,17 +25,36 @@ const TWITCH_ANCESTORS = [
 /** Converts the twitch clip link to a video embed url */
 export async function twitchClipEmbed(post: RedditPost, link: string, head: HTMLElement) {
     const url: URL = new URL(link);
-    const slug = url.pathname.substring(1);
-    url.pathname = '/embed';
-    url.searchParams.set('clip', slug);
+    let slug: string;
+
+    // Handle different URL formats
+    // https://www.twitch.tv/varidetta/clip/xx123 need to convert to 
+    // https://clips.twitch.tv/embed?clip=xx123 for embedding
+    if (url.hostname === 'clips.twitch.tv') {
+        slug = url.searchParams.get('clip') || '';
+    } else {
+        const pathParts = url.pathname.split('/');
+
+        // The slug is always the part after 'clip/' in the path
+        const clipIndex = pathParts.indexOf('clip');
+        if (clipIndex !== -1 && clipIndex + 1 < pathParts.length) {
+            slug = pathParts[clipIndex + 1];
+        } else {
+            // Fallback to the old method if the path structure is different
+            slug = url.pathname.substring(1);
+        }
+    }
+
+    const embedUrl = new URL('https://clips.twitch.tv/embed');
+    embedUrl.searchParams.set('clip', slug);
 
     // This is required so the csp allows us to embed the video
     // idk what twitch was thinking on this one my dudes
     for (const parent of TWITCH_ANCESTORS) {
-        url.searchParams.append('parent', parent);
+        embedUrl.searchParams.append('parent', parent);
     }
 
-    head.video(url.toString(), post.oembed?.width, post.oembed?.height, 'text/html');
+    head.video(embedUrl.toString(), post.oembed?.width, post.oembed?.height, 'text/html');
 
     if (post.oembed?.thumbnail_url) {
         head.image(post.oembed.thumbnail_url, post.oembed?.thumbnail_width, post.oembed?.thumbnail_height);

--- a/src/reddit/compile.ts
+++ b/src/reddit/compile.ts
@@ -30,6 +30,7 @@ function getDomainHandler(domain?: string) {
                 type: 'video.other',
             };
         case 'clips.twitch.tv':
+        case 'twitch.tv':
             return {
                 handler: twitchClipEmbed,
                 type: 'video.other',


### PR DESCRIPTION
A lot of clips are posted to reddit not on the `clips.twitch.tv` domain, but instead from the main `twitch.tv` domain. These have a url format similar to `https://www.twitch.tv/varidetta/clip/xx123` vs the clips subdomain's `https://clips.twitch.tv/embed?clip=xx123`. The current twitch handler does not currently handle posts not from the clips domain.  
  
This change adds the functionality to embed clips from the `twitch.tv` domain. This requires a slightly different way of grabbing the clip slug and then generating the embed from it. 

https://old.reddit.com/domain/twitch.tv/ has plenty of posts to try this with.